### PR TITLE
Implement signal integer and signal exit status and init signals

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: dsamuel <dsamuel@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/09 22:23:45 by dsamuel           #+#    #+#             */
-/*   Updated: 2024/10/10 19:13:36 by dsamuel          ###   ########.fr       */
+/*   Updated: 2024/10/11 21:22:52 by dsamuel          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,7 @@
 # define ERROR 1
 # define SUCCESS 0
 # define IS_DIRECTORY 126
-# define UNKNOWN_COMMAND 127
+# define UNKNOWN_CMD 127
 
 /*
 ** Structure for storing a command token (e.g., a command, argument, pipe, etc.).
@@ -64,7 +64,7 @@ typedef struct s_cmd_token
 {
 	char				*content;
 	int					type;
-	struct s_cmd_token	*previous;
+	struct s_cmd_token	*prev;
 	struct s_cmd_token	*next;
 }					t_cmd_token;
 
@@ -155,5 +155,21 @@ void	cmd_echo(char **args);
 /*
 ** PARSING
 */
+
+/*
+** SIGNALS HANDLING
+*/
+void	*ft_memdel(void *ptr); // remember to move to libft
+void	ft_signal_int(int signal);
+void	ft_signal_exit(int signal);
+void	ft_sig_init(void);
+
+/*
+** External functions
+*/
+extern t_sig_handler global_sig;
+
+
+
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: dsamuel <dsamuel@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/09 22:23:45 by dsamuel           #+#    #+#             */
-/*   Updated: 2024/10/11 21:22:52 by dsamuel          ###   ########.fr       */
+/*   Updated: 2024/10/11 21:27:51 by dsamuel          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -160,8 +160,8 @@ void	cmd_echo(char **args);
 ** SIGNALS HANDLING
 */
 void	*ft_memdel(void *ptr); // remember to move to libft
-void	ft_signal_int(int signal);
-void	ft_signal_exit(int signal);
+void	ft_sig_integer(int signal);
+void	ft_sig_exit(int signal);
 void	ft_sig_init(void);
 
 /*

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -6,7 +6,7 @@
 /*   By: dsamuel <dsamuel@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/11 20:00:14 by dsamuel           #+#    #+#             */
-/*   Updated: 2024/10/11 21:00:22 by dsamuel          ###   ########.fr       */
+/*   Updated: 2024/10/11 21:26:34 by dsamuel          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,7 @@ void	*ft_memdel(void *ptr)
  * @param signal The signal number (typically SIGINT).
  *               This parameter is unused but included for compatibility.
  */
-void	ft_signal_init(int signal)
+void	ft_sig_integer(int signal)
 {
 	(void)signal;
 	if (global_sig.child_proc_id == 0)
@@ -94,7 +94,7 @@ void	ft_signal_init(int signal)
  *
  * @param signal The signal number (typically SIGQUIT).
  */
-void	ft_signal_exit(int signal)
+void	ft_sig_exit(int signal)
 {
 	char	*nbr;
 
@@ -109,4 +109,20 @@ void	ft_signal_exit(int signal)
 	else
 		ft_putstr_fd("\b\b  \b\b", STDERR);
 	ft_memdel(nbr);
+}
+
+/**
+ * @brief Initializes the signal handlers for the minishell.
+ *
+ * This function sets up the signal handlers for the minishell to handle
+ * SIGINT (Ctrl+C) and SIGQUIT (Ctrl+\) signals. It uses the `signal` function
+ * to register the signal handlers `ft_signal_init` and `ft_signal_exit`
+ * for the respective signals.
+ */
+void	ft_sig_init(void)
+{
+	global_sig.sigint_received = 0;
+	global_sig.sigquit_received = 0;
+	global_sig.last_exit_stat = 0;
+	global_sig.child_proc_id = 0;
 }

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -6,7 +6,7 @@
 /*   By: dsamuel <dsamuel@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/11 20:00:14 by dsamuel           #+#    #+#             */
-/*   Updated: 2024/10/11 20:54:38 by dsamuel          ###   ########.fr       */
+/*   Updated: 2024/10/11 21:00:22 by dsamuel          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,8 +28,7 @@
  *   // str is now NULL after being freed.
  *  we will need to move to libft implementation
  */
-
-void*ft_memdel(void *ptr)
+void	*ft_memdel(void *ptr)
 {
 	if (ptr)
 	{
@@ -39,6 +38,25 @@ void*ft_memdel(void *ptr)
 	return (NULL);
 }
 
+/**
+ * @brief Handles the SIGINT signal (Ctrl+C) for the minishell.
+ *
+ * This function is called when a SIGINT signal is received by the shell.
+ * It differentiates between when a child process is running and when the
+ * shell is in the foreground without a child process.
+ * - If no child process is running (`global_sig.child_proc_id == 0`):
+ *   - Prints a new line followed by the shell prompt to `STDERR`.
+ *   - Sets the `last_exit_stat` to 1 to indicate an interrupted command.
+ * - If a child process is running:
+ *   - Prints a newline to indicate the interruption.
+ *   - Sets `last_exit_stat` to 130, which is the typical exit code for
+ *     a process terminated by SIGINT.
+ * - Updates `global_sig.sigint_received` to 1, indicating that a SIGINT
+ *   signal has been received.
+ *
+ * @param signal The signal number (typically SIGINT).
+ *               This parameter is unused but included for compatibility.
+ */
 void	ft_signal_init(int signal)
 {
 	(void)signal;
@@ -57,6 +75,25 @@ void	ft_signal_init(int signal)
 	global_sig.sigint_received = 1;
 }
 
+/**
+ * @brief Handles the SIGQUIT signal (Ctrl+\) for the minishell.
+ *
+ * This function is called when a SIGQUIT signal is received by the shell.
+ * It differentiates between when a child process is running and when the
+ * shell is in the foreground without a child process.
+ * - Converts the signal number to a string using `ft_itoa` for display.
+ * - If a child process is running (`global_sig.child_proc_id != 0`):
+ *   - Prints a message indicating the quit signal (`^\\`) to `STDERR`.
+ *   - Prints the signal number (131) to indicate the process was
+ *     terminated by SIGQUIT.
+ *   - Sets `last_exit_stat` to 131, which is the typical exit code for
+ *     a process terminated by SIGQUIT.
+ *   - Sets `sigquit_received` to 1 to indicate that SIGQUIT was received.
+ * - If no child process is running, it suppresses the default output.
+ * - Frees the memory allocated for the signal number string using `ft_memdel`.
+ *
+ * @param signal The signal number (typically SIGQUIT).
+ */
 void	ft_signal_exit(int signal)
 {
 	char	*nbr;

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -12,22 +12,7 @@
 
 #include "minishell.h"
 
-/**
- * @brief Frees the memory pointed to by `ptr` and sets the pointer to NULL.
- *
- * This function is used to safely free dynamically allocated memory
- * and set the pointer to NULL to avoid dangling pointers.
- * It ensures that `ptr` is not NULL before attempting to free it.
- *
- * @param ptr A pointer to the memory to be freed.
- * @return Always returns NULL, making it easier to reset the pointer.
- *
- * Usage:
- *   char *str = malloc(100);
- *   str = ft_memdel(str);
- *   // str is now NULL after being freed.
- *  we will need to move to libft implementation
- */
+
 void	*ft_memdel(void *ptr)
 {
 	if (ptr)
@@ -38,25 +23,7 @@ void	*ft_memdel(void *ptr)
 	return (NULL);
 }
 
-/**
- * @brief Handles the SIGINT signal (Ctrl+C) for the minishell.
- *
- * This function is called when a SIGINT signal is received by the shell.
- * It differentiates between when a child process is running and when the
- * shell is in the foreground without a child process.
- * - If no child process is running (`global_sig.child_proc_id == 0`):
- *   - Prints a new line followed by the shell prompt to `STDERR`.
- *   - Sets the `last_exit_stat` to 1 to indicate an interrupted command.
- * - If a child process is running:
- *   - Prints a newline to indicate the interruption.
- *   - Sets `last_exit_stat` to 130, which is the typical exit code for
- *     a process terminated by SIGINT.
- * - Updates `global_sig.sigint_received` to 1, indicating that a SIGINT
- *   signal has been received.
- *
- * @param signal The signal number (typically SIGINT).
- *               This parameter is unused but included for compatibility.
- */
+
 void	ft_sig_integer(int signal)
 {
 	(void)signal;
@@ -75,25 +42,7 @@ void	ft_sig_integer(int signal)
 	global_sig.sigint_received = 1;
 }
 
-/**
- * @brief Handles the SIGQUIT signal (Ctrl+\) for the minishell.
- *
- * This function is called when a SIGQUIT signal is received by the shell.
- * It differentiates between when a child process is running and when the
- * shell is in the foreground without a child process.
- * - Converts the signal number to a string using `ft_itoa` for display.
- * - If a child process is running (`global_sig.child_proc_id != 0`):
- *   - Prints a message indicating the quit signal (`^\\`) to `STDERR`.
- *   - Prints the signal number (131) to indicate the process was
- *     terminated by SIGQUIT.
- *   - Sets `last_exit_stat` to 131, which is the typical exit code for
- *     a process terminated by SIGQUIT.
- *   - Sets `sigquit_received` to 1 to indicate that SIGQUIT was received.
- * - If no child process is running, it suppresses the default output.
- * - Frees the memory allocated for the signal number string using `ft_memdel`.
- *
- * @param signal The signal number (typically SIGQUIT).
- */
+
 void	ft_sig_exit(int signal)
 {
 	char	*nbr;
@@ -111,14 +60,7 @@ void	ft_sig_exit(int signal)
 	ft_memdel(nbr);
 }
 
-/**
- * @brief Initializes the signal handlers for the minishell.
- *
- * This function sets up the signal handlers for the minishell to handle
- * SIGINT (Ctrl+C) and SIGQUIT (Ctrl+\) signals. It uses the `signal` function
- * to register the signal handlers `ft_signal_init` and `ft_signal_exit`
- * for the respective signals.
- */
+
 void	ft_sig_init(void)
 {
 	global_sig.sigint_received = 0;

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -1,0 +1,75 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signals.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dsamuel <dsamuel@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/10/11 20:00:14 by dsamuel           #+#    #+#             */
+/*   Updated: 2024/10/11 20:54:38 by dsamuel          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/**
+ * @brief Frees the memory pointed to by `ptr` and sets the pointer to NULL.
+ *
+ * This function is used to safely free dynamically allocated memory
+ * and set the pointer to NULL to avoid dangling pointers.
+ * It ensures that `ptr` is not NULL before attempting to free it.
+ *
+ * @param ptr A pointer to the memory to be freed.
+ * @return Always returns NULL, making it easier to reset the pointer.
+ *
+ * Usage:
+ *   char *str = malloc(100);
+ *   str = ft_memdel(str);
+ *   // str is now NULL after being freed.
+ *  we will need to move to libft implementation
+ */
+
+void*ft_memdel(void *ptr)
+{
+	if (ptr)
+	{
+		free(ptr);
+		ptr = NULL;
+	}
+	return (NULL);
+}
+
+void	ft_signal_init(int signal)
+{
+	(void)signal;
+	if (global_sig.child_proc_id == 0)
+	{
+		ft_putstr_fd("\b\b", STDERR);
+		ft_putstr_fd("\n", STDERR);
+		ft_putstr_fd("\033[0;36m\033[1m minishell ▸ \033[0m", STDERR);
+		global_sig.last_exit_stat = 1;
+	}
+	else
+	{
+		ft_putstr_fd("\n", STDERR);
+		global_sig.last_exit_stat = 130;
+	}
+	global_sig.sigint_received = 1;
+}
+
+void	ft_signal_exit(int signal)
+{
+	char	*nbr;
+
+	nbr = ft_itoa(signal);
+	if (global_sig.child_proc_id != 0)
+	{
+		ft_putstr_fd("\b\b \b\b", STDERR);
+		ft_putendl_fd(nbr, STDERR);
+		global_sig.last_exit_stat = 131;
+		global_sig.sigquit_received = 1;
+	}
+	else
+		ft_putstr_fd("\b\b  \b\b", STDERR);
+	ft_memdel(nbr);
+}


### PR DESCRIPTION
In this milestone I completed the following
- [x] implement ft_memdel to safely free memory and set pointers to NULL.
- [x] Implement ft_signal_init to handle SIGINT:
- [x] Ensure proper display of the shell prompt when interrupted.
- [x] Update the global signal status for interrupted processes.
- [x] Implement ft_signal_exit to handle SIGQUIT:
- [x] Manage the display and status update when a child process is terminated by SIGQUIT.

Update global signal status and exit code accordingly.

Ensure memory management functions are integrated with signal handling to prevent memory leaks.
- Implement signals this closes #20
